### PR TITLE
fix: add main entry point to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "12.1.2",
   "description": "An isomorphic http client for Svelte apps",
   "type": "module",
+  "main": "./dist/index.cjs",
   "repository": {
     "type": "git",
     "url": "https://github.com/beyonk-adventures/http.git"


### PR DESCRIPTION
This is for the sapper apps, which don't read `exports` field. Modern bundlers will default to `exports`, so they will avoid picking up the `main` field